### PR TITLE
feat: Interactive RAG Chat & Critical State Aggregation Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ I've been thinking a lot about how we, as people, develop ideas. It's rarely a s
 
 I wanted to see if I could recreate a small-scale version of that "soup" required for true insight, for local LLMs. The result is this project, Network of Agents (NoA).
 
+## ⚠️ Alpha Software - We Need Your Help! ⚠️
+Please be aware that NoA is currently in an alpha stage. It is experimental research software, and you may encounter bugs, unexpected behavior, or breaking changes.
+
+Your feedback is invaluable. If you run into issues, have ideas, or want to contribute, please **open an issue** on our GitHub repository. Helping us identify and squash bugs is one of the most important contributions you can make right now!
+
 ## **Is true "deep thinking" only for trillion-dollar companies?**
 NoA is a research platform that challenges the paradigm of centralized, proprietary AI. While systems like Google's DeepThink offer powerful reasoning by giving their massive models more "thinking time" in a closed environment, NoA explores a different path: **emergent intelligence**. We simulate a society of AI agents that collaborate, critique, and evolve their understanding collectively. The best part is that you don't need a supercomputer. NoA is designed to turn even a modest 32gb RAM laptop into a powerful "thought mining" rig. 💻⛏️ By leveraging efficient local models (like a quantized 30B-a3b parameter version of Qwen), you can leave the graph-network running for hours or even days, allowing it to iteratively refine its approach and "mine" a sophisticated solution to a hard problem. It's a fundamental shift: trading brute-force, instantaneous computation for the power of time, iteration, and distributed collaboration.  
 
@@ -14,9 +19,11 @@ https://github.com/user-attachments/assets/009abf33-9083-4d6c-a5fa-3936bba48243
 
 ## Changelog
 
+*   **Interactive RAG Chat & Diagnostic Tool:** The process now pauses after the final epoch, allowing you to directly **chat with the generated RAG index**. This powerful diagnostic feature lets you interrogate the massive "cube of thinking text" from all hidden layers, ask follow-up questions, and gain extra insights beyond the automated academic questions. Your entire chat conversation is then archived and included in the final knowledge harvest, enriching the final report.
+
 *   **Final Knowledge Harvest & RAG:** The run doesn't just end with a final answer anymore. All agent outputs from all epochs are now archived into a multi-layered RAPTOR (Recursive Abstractive Processing over Trees of RAG) index. Upon completion, an `interrogator` agent generates a series of expert-level questions about the original problem, and a `paper_formatter` agent uses the RAG index to write a formal academic-style paper answering each question. The final output is now a downloadable ZIP file containing this collection of research papers.
 
-*   **Dynamic Critique Annealing:** The network previosuly static "loss function" now evolves. A new meta-process analyzes the collective output of the hidden-layer agents after each epoch to determine their collective affinity. It then selects a "pseudo-neurotransmitter" that dynamically rewrites the system prompt of the critique agent, changing its persona (e.g., from a 'senior manager' to a 'cynical philosopher-king') to provide a different style of feedback for the next epoch.
+*   **Dynamic Critique Annealing:** The network previously static "loss function" now evolves. A new meta-process analyzes the collective output of the hidden-layer agents after each epoch to determine their collective affinity. It then selects a "pseudo-neurotransmitter" that dynamically rewrites the system prompt of the critique agent, changing its persona (e.g., from a 'senior manager' to a 'cynical philosopher-king') to provide a different style of feedback for the next epoch.
 
 *   **Dynamic Problem Re-framing:** The network can now assess its own progress. If it determines it has made a "significant breakthrough," it formulates a new, more advanced problem that builds upon its success. This turns the process from simple refinement into a genuine journey of discovery.
 
@@ -79,9 +86,11 @@ When the final epoch is complete, the process is not over. The network enters a 
 
 1.  **Archival and RAG Indexing**: An `archive_epoch_outputs` node gathers every single agent output from every epoch of the entire run. This collection of documents is then used to build a comprehensive, multi-layered RAPTOR RAG index, creating a searchable knowledge base of the entire thought process.
 
-2.  **Interrogation and Synthesis**: A `final_harvest` node takes over. It uses an `interrogator` agent to generate a series of deep, expert-level questions about the original problem. For each question, it performs a retrieval query against the RAG index and feeds the context to a `paper_formatter` agent.
+2.  **Pause for Interactive Chat**: At this point, the network pauses. The user is presented with a chat interface, allowing them to directly query the newly created RAG index. This serves as a powerful diagnostic tool, enabling the user to probe the network's collective "mind," ask clarifying questions, and explore threads of reasoning before the final summarization.
 
-3.  **Generating the Final Report**: The `paper_formatter` synthesizes the retrieved context into a formal, academic-style markdown document. The final output of the entire run is a downloadable ZIP archive containing this collection of research papers, representing the network's total accumulated knowledge on the topic.
+3.  **Interrogation and Synthesis**: When the user concludes the chat session, the entire conversation is converted into documents and added to the knowledge base, which is re-indexed. A `final_harvest` node then takes over. It uses an `interrogator` agent to generate a series of deep, expert-level questions about the original problem. For each question, it performs a retrieval query against the RAG index and feeds the context to a `paper_formatter` agent.
+
+4.  **Generating the Final Report**: The `paper_formatter` synthesizes the retrieved context into a formal, academic-style markdown document. The final output of the entire run is a downloadable ZIP archive containing this collection of research papers, representing the network's total accumulated knowledge on the topic.
 
 ## Vision & Long-Term Roadmap: Training a World Language Model
 
@@ -147,9 +156,13 @@ The application is built with a Python backend and a vanilla HTML/CSS/JS fronten
 
 4.  **Install and Run Ollama**: This application requires a running Ollama server for local inference.
     *   Follow the official instructions to install Ollama.
-    *   Download a model. The default is `dengcao/Qwen3-30B-A3B-Instruct-2507:latest`.
+    *   Download the primary model. The default is `dengcao/Qwen3-30B-A3B-Instruct-2507:latest`.
         ```bash
         ollama pull dengcao/Qwen3-30B-A3B-Instruct-2507:latest
+        ```
+    *   **Download the compulsory summarization model.** NoA requires `qwen3:1.7b` for its internal summarization tasks (memory, RAG indexing). This is not optional.
+        ```bash
+        ollama pull qwen3:1.7b
         ```
     *   Ensure the Ollama application is running in the background.
 
@@ -166,7 +179,8 @@ The application is built with a Python backend and a vanilla HTML/CSS/JS fronten
 2.  **Pose a Problem**: Enter the high-level prompt you want the agent network to solve.
 3.  **Build and Run**: Click the "Build and Run Graph" button to initiate the process.
 4.  **Observe the Emergence**: The backend dynamically constructs the agent network using LangGraph. You can monitor the entire process—agent creation, forward inference, and reflective learning—in the real-time log viewer.
-5.  **Download the Final Report**: Once all epochs are complete, the final harvest phase will run. A download link for a ZIP file containing the generated research papers will appear.
+5.  **Chat and Diagnose**: Once the epochs are complete, the GUI will present a chat interface. Use this to directly query the RAG index of the network's entire thought process. Ask follow-up questions and probe for deeper insights.
+6.  **Harvest and Download**: When you are finished chatting, click the "HARVEST" button. This will incorporate your chat history and generate the final report. A download link for a ZIP file containing the research papers will appear.
 
 ## Let's Collaborate: Building a P2P Network
 

--- a/index.html
+++ b/index.html
@@ -179,6 +179,65 @@
         #download-log-button:hover:not(:disabled), .download-paper-button:hover:not(:disabled), #download-report-button:hover:not(:disabled) {
             background-color: #3a3b44;
         }
+        #chat-messages {
+            height: 400px;
+            background-color: #000;
+            border: 1px solid var(--secondary-color);
+            border-radius: var(--border-radius);
+            padding: 1rem;
+            margin-bottom: 1rem;
+            overflow-y: auto;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+        }
+        .chat-message {
+            padding: 0.75rem 1rem;
+            border-radius: var(--border-radius);
+            max-width: 80%;
+            line-height: 1.5;
+            word-wrap: break-word;
+        }
+        .user-message {
+            background-color: var(--accent-color);
+            color: var(--text-color);
+            align-self: flex-end;
+            border-bottom-right-radius: 0;
+        }
+        .ai-message {
+            background-color: var(--secondary-color);
+            color: var(--text-color);
+            align-self: flex-start;
+            border-bottom-left-radius: 0;
+            white-space: pre-wrap;
+        }
+        #chat-form {
+            display: flex;
+            gap: 1rem;
+        }
+        #chat-input {
+            flex-grow: 1;
+            min-height: 50px;
+            height: 50px;
+            margin-bottom: 0;
+            resize: none;
+        }
+        #chat-send-button {
+            width: auto;
+            margin-bottom: 0;
+            align-self: flex-end;
+        }
+        #harvest-button {
+            width: auto;
+            padding: 0.5rem 1.5rem;
+            margin-bottom: 0;
+            font-size: 1rem;
+            font-weight: bold;
+            background-color: #28a745;
+        }
+        #harvest-button:hover:not(:disabled) {
+            background-color: #218838;
+        }
 
     </style>
 </head>
@@ -241,6 +300,18 @@
         <h2>Average Perplexity per Epoch</h2>
         <canvas id="perplexityChart"></canvas>
     </div>
+    <!-- NEW: Container for Chat -->
+    <div class="container hidden" id="chat-container">
+        <div class="header-with-button">
+            <h2>Chat with the hidden layer (diagnose, or get specific answers for your request) </h2>
+            <button id="harvest-button">HARVEST</button>
+        </div>
+        <div id="chat-messages"></div>
+        <form id="chat-form">
+            <textarea id="chat-input" placeholder="Ask a question about the generated knowledge..." required></textarea>
+            <button type="submit" id="chat-send-button">Send</button>
+        </form>
+    </div>
     <div class="container">
         <div class="header-with-button">
             <h2>Real-time Graph Activity</h2>
@@ -278,8 +349,6 @@
     const runButton = document.getElementById('run-button');
     const logContainer = document.getElementById('log-container');
     const graphContainer = document.getElementById('graph-container');
-    const llmProviderSelect = "Ollama";
-
     const ollamaModelSection = document.getElementById('ollama-model-section');
     const debugModeCheckbox = document.getElementById('debug_mode');
     const downloadLogButton = document.getElementById('download-log-button');
@@ -287,11 +356,19 @@
     const downloadReportButton = document.getElementById('download-report-button');
     const perplexityChartContainer = document.getElementById('perplexity-chart-container');
     const perplexityChartCanvas = document.getElementById('perplexityChart').getContext('2d');
+    const graphArchitectureSection = document.getElementById('graph-architecture');
+    const chatContainer = document.getElementById('chat-container');
+    const chatMessages = document.getElementById('chat-messages');
+    const chatForm = document.getElementById('chat-form');
+    const chatInput = document.getElementById('chat-input');
+    const harvestButton = document.getElementById('harvest-button');
+
 
     let fullLogContent = '';
     let perplexityChart = null;
     let allPerplexityValues = [];
     let allLbelsData = [];
+    let currentSessionId = null;
 
     debugModeCheckbox.addEventListener('change', (e) => {
         const isDebug = e.target.checked;
@@ -303,7 +380,6 @@
         if (downloadLogButton.disabled) {
             downloadLogButton.disabled = false;
         }
-        // Use <pre> for JSON to preserve formatting
         const container = (text.trim().startsWith('{') && text.trim().endsWith('}')) ? document.createElement('pre') : document.createElement('p');
         container.style.margin = '0';
         container.style.lineHeight = '1.4';
@@ -369,6 +445,110 @@
         });
     };
 
+    const handleChatSubmit = async (e) => {
+        e.preventDefault();
+        const message = chatInput.value.trim();
+        if (!message || !currentSessionId) return;
+
+        const userMsgDiv = document.createElement('div');
+        userMsgDiv.className = 'chat-message user-message';
+        userMsgDiv.textContent = message;
+        chatMessages.appendChild(userMsgDiv);
+        chatMessages.scrollTop = chatMessages.scrollHeight;
+
+        chatInput.value = '';
+        chatInput.disabled = true;
+
+        const aiMsgDiv = document.createElement('div');
+        aiMsgDiv.className = 'chat-message ai-message';
+        aiMsgDiv.textContent = '...';
+        chatMessages.appendChild(aiMsgDiv);
+        chatMessages.scrollTop = chatMessages.scrollHeight;
+
+        try {
+            const response = await fetch('/chat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ session_id: currentSessionId, message: message })
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                aiMsgDiv.textContent = `Error: ${errorText}`;
+                return;
+            }
+
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder();
+            let aiResponseText = '';
+            aiMsgDiv.textContent = '';
+
+            while (true) {
+                const { value, done } = await reader.read();
+                if (done) break;
+                const chunk = decoder.decode(value, { stream: true });
+                aiResponseText += chunk;
+                aiMsgDiv.textContent = aiResponseText;
+                chatMessages.scrollTop = chatMessages.scrollHeight;
+            }
+        } catch (error) {
+            aiMsgDiv.textContent = `Error: ${error.message}`;
+        } finally {
+            chatInput.disabled = false;
+            chatInput.focus();
+        }
+    };
+
+    const handleHarvestClick = async () => {
+        if (!currentSessionId) return;
+
+        harvestButton.disabled = true;
+        chatInput.disabled = true;
+        harvestButton.textContent = 'Harvesting...';
+        addLogMessage(`--- [HARVEST] User initiated final harvest for session ${currentSessionId} ---`, { color: 'yellow' });
+
+        try {
+            const response = await fetch('/harvest', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ session_id: currentSessionId })
+            });
+            const result = await response.json();
+
+            if (!response.ok) {
+                addLogMessage(`Error during harvest: ${result.message}`, { color: 'red' });
+                if (result.traceback) {
+                    addLogMessage(result.traceback, { isHTML: false });
+                }
+                return;
+            }
+            
+            addLogMessage(`<strong>✅ ${result.message}</strong>`, { isHTML: true, color: 'lime' });
+
+            if (result.session_id) {
+                addLogMessage(`Report generated successfully. Session ID: ${result.session_id}`, { color: 'cyan' });
+                reportContainer.classList.remove('hidden');
+                downloadReportButton.onclick = () => {
+                    window.location.href = `/download_report/${result.session_id}`;
+                };
+            } else {
+                 addLogMessage(`⚠️ Server finished but no downloadable report was generated.`, { color: 'orange' });
+            }
+
+            chatContainer.classList.add('hidden');
+            graphArchitectureSection.classList.remove('hidden');
+            
+        } catch (error) {
+            addLogMessage(`Client-side error during harvest: ${error.message}`, { color: 'red' });
+        } finally {
+            harvestButton.disabled = false;
+            harvestButton.textContent = 'HARVEST';
+            runButton.disabled = false;
+            runButton.textContent = 'Build and Run Graph';
+            currentSessionId = null;
+        }
+    };
+
     graphParamsForm.addEventListener('submit', async (e) => {
         e.preventDefault();
         const formData = new FormData(graphParamsForm);
@@ -401,7 +581,6 @@
         allPerplexityValues = [];
         allLbelsData = [];
 
-
         addLogMessage('Sending request to build and run graph...');
         try {
             const response = await fetch('/build_and_run_graph', {
@@ -418,23 +597,21 @@
                     pre.textContent = result.traceback;
                     logContainer.appendChild(pre);
                 }
+                runButton.disabled = false;
+                runButton.textContent = 'Build and Run Graph';
                 return;
             }
-            addLogMessage(`<strong>✅ ${result.message}</strong>`, { isHTML: true, color: 'lime' });
-
-            if (result.session_id) {
-                addLogMessage(`Report generated successfully. Session ID: ${result.session_id}`, { color: 'cyan' });
-                reportContainer.classList.remove('hidden');
-                downloadReportButton.onclick = () => {
-                    window.location.href = `/download_report/${result.session_id}`;
-                };
-            } else {
-                 addLogMessage(`⚠️ Server finished but no downloadable report was generated.`, { color: 'orange' });
+            
+            if (result.message === "Chat is now active.") {
+                addLogMessage(`<strong>✅ RAG Index ready. Chat is now active.</strong>`, { isHTML: true, color: 'lime' });
+                currentSessionId = result.session_id;
+                graphArchitectureSection.classList.add('hidden');
+                chatContainer.classList.remove('hidden');
+                chatInput.focus();
             }
 
         } catch (error) {
             addLogMessage(`A client-side error occurred: ${error.message}`, { color: 'red' });
-        } finally {
             runButton.disabled = false;
             runButton.textContent = 'Build and Run Graph';
         }
@@ -466,6 +643,16 @@
         addLogMessage("Error: Connection to server log stream lost. Please refresh and try again.", { color: 'red' });
         eventSource.close();
     };
+
+    chatForm.addEventListener('submit', handleChatSubmit);
+    harvestButton.addEventListener('click', handleHarvestClick);
+    chatInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            chatForm.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }));
+        }
+    });
+
 </script>
 </body>
 </html>


### PR DESCRIPTION
Key Changes

✨ New Feature: Interactive RAG Chat

After the main graph execution finishes, the application now pauses and displays a new, elegant chat interface.
A new /chat endpoint handles streaming user queries against the generated RAPTOR index, providing real-time answers.
A new /harvest endpoint and a prominent "HARVEST" button have been added to the UI. This finalizes the session, incorporates the chat history into the knowledge base, and generates the final report.

An active_sessions dictionary has been added to the backend to manage the state of paused runs, allowing users to interact with their specific RAG index.

🐛 Critical Bug Fix: KeyError: 'all_rag_documents'

Root Cause: The previous implementation using graph.astream() only yielded the output of the last processed node, not the final aggregated state of the entire graph. This meant essential keys like all_rag_documents, which were created in earlier nodes, were missing from the final state object passed to the session.
Solution: The graph execution loop in /build_and_run_graph has been rewritten to manually aggregate the state. It now iterates through the stream of node outputs and correctly merges them into a complete final_aggregated_state dictionary, mirroring LangGraph's internal state management. This ensures the chat session starts with the complete, correct state.

📝 Documentation Overhaul (README.md)
The README.md has been significantly updated to reflect all new features, including the interactive chat and final harvest process.
Added a prominent alpha software disclaimer, encouraging users to report bugs and contribute.
Emphasized the compulsory requirement of the qwen3:1.7b model for summarization tasks.
Clarified the concept of using the chat for diagnostics and gaining extra insight into the "cube of thinking text."
Motivation
Enhance User Interaction and Diagnostics: The primary goal was to move beyond a static "fire-and-forget" process. The chat interface provides a powerful, human-in-the-loop step, allowing users to perform diagnostics, validate the network's understanding, and explore emergent lines of thought before committing to the final knowledge extraction.
Ensure Application Stability: The KeyError bug made the application unusable after a successful run. Fixing the state aggregation logic was critical to making the entire post-run and harvest functionality work as intended.

How to Test

Pull down this branch and ensure all dependencies from requirements.txt are installed.
Ensure you have both the primary model (e.g., dengcao/Qwen3-30B-A3B-Instruct-2507:latest) and the summarizer model (qwen3:1.7b) pulled in Ollama.
Run the application with uvicorn app:app --reload.
Open the GUI, configure a run (it is recommended to use Debug Mode and 1 epoch for faster testing), and click "Build and Run Graph".
Observe that after the run completes, the main configuration section hides and the new "Chat with RAG Index" interface appears.
Send several messages to the chat and verify that you receive streaming responses from the backend.
Click the "HARVEST" button.
Observe in the logs that the harvest process begins, incorporates chat history, and completes successfully.
Verify that the "Final Report" section appears with a working "Download Full Report (.zip)" button.
Checklist
The new chat feature is fully implemented and functional.
The KeyError during the harvest phase is resolved.
State is correctly aggregated and maintained between the graph run and the user chat session.

The README is updated with all relevant changes and new instructions.
The application has been tested locally in both normal and debug modes.