### PR TITLE
Add Requesty as an OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ These artifacts are the real product. The final synthesized answer is a byproduc
 
 - Built on **LangGraph** with real cyclic graphs, conditional routing (epoch gateway), parallel layer execution, and proper state management — not a pile of sequential chains.
 - 195 passing tests across 11 phases, including regression tests for every bug fixed in the 0.0.3 quality release.
-- Clean provider model: only OpenRouter (cloud) and llama.cpp server (local). Per-agent and per-synthesis model selection supported.
+- Clean provider model: OpenRouter, Requesty (both OpenAI-compatible cloud) and llama.cpp server (local). Per-agent and per-synthesis model selection supported.
 - Robust JSON handling, token tracking, streaming logs, RAPTOR hierarchical indexing, and safe(ish) code execution.
 - Real export/import of full QNN state.
 - Massive scale supported when you ask for it (Manual/Massive mode will happily run 50×50+ if your budget allows).
@@ -139,7 +139,7 @@ launch.bat                       # or: python app.py
 
 Open http://127.0.0.1:8000.
 
-**Supported providers**: OpenRouter (bring your own key) and local llama.cpp server.
+**Supported providers**: OpenRouter and Requesty (bring your own key) and local llama.cpp server.
 
 See the in-app UI for the three modes, topology visualization, token budgeting (especially important for Distillation), and export controls.
 

--- a/app.py
+++ b/app.py
@@ -2394,9 +2394,16 @@ async def build_and_run_graph(payload: dict = Body(...)):
     token_tracker = TokenUsageTracker(log_stream)
 
     try:
-        # Determine Provider - only OpenRouter and LlamaCpp supported
+        # Determine Provider - OpenRouter, Requesty (both OpenAI-compatible cloud) and LlamaCpp supported
         provider = params.get("provider", "openrouter")
         api_key = params.get("api_key", "")
+
+        # Base URL for the selected OpenAI-compatible cloud provider (OpenRouter / Requesty)
+        cloud_api_base = (
+            "https://router.requesty.ai/v1"
+            if provider == "requesty"
+            else "https://openrouter.ai/api/v1"
+        )
 
         # Hoist common config and model choices for per-agent / synthesis support (visible in all branches)
         openrouter_model = params.get("openrouter_model", "stepfun/step-3.5-flash:free")
@@ -2411,7 +2418,7 @@ async def build_and_run_graph(payload: dict = Body(...)):
         llamacpp_api_key = "no-key-required"
 
         default_agent_model = (
-            openrouter_model if provider == "openrouter" else llamacpp_model
+            openrouter_model if provider in ("openrouter", "requesty") else llamacpp_model
         )
 
         synthesis_model = params.get("synthesis_model", "").strip()
@@ -2422,36 +2429,38 @@ async def build_and_run_graph(payload: dict = Body(...)):
             else []
         )
 
-        if provider == "openrouter":
+        if provider in ("openrouter", "requesty"):
+            provider_label = "Requesty" if provider == "requesty" else "OpenRouter"
             if not api_key:
                 return JSONResponse(
-                    content={"message": "OpenRouter API Key required"}, status_code=400
+                    content={"message": f"{provider_label} API Key required"},
+                    status_code=400,
                 )
             # use hoisted openrouter_model as default for agents
             default_agent_model = openrouter_model
             llm = ChatOpenAI(
                 model=default_agent_model,
                 openai_api_key=api_key,
-                openai_api_base="https://openrouter.ai/api/v1",
+                openai_api_base=cloud_api_base,
                 temperature=0.7,
                 callbacks=[token_tracker],
             )
             summarizer_llm = llm
-            # Use OpenAIEmbeddings with OpenRouter base URL (works for many OpenRouter embedding models)
+            # Use OpenAIEmbeddings with the cloud provider base URL (works for many cloud embedding models)
             try:
                 embeddings_model = OpenAIEmbeddings(
                     model="google/gemini-embedding-001",
                     openai_api_key=api_key,
-                    openai_api_base="https://openrouter.ai/api/v1",
+                    openai_api_base=cloud_api_base,
                     check_embedding_ctx_length=False,
                 )
                 await log_stream.put(
-                    f"--- Initializing Main Agent LLM: OpenRouter ({default_agent_model}) & Embeddings ---"
+                    f"--- Initializing Main Agent LLM: {provider_label} ({default_agent_model}) & Embeddings ---"
                 )
             except Exception as e:
                 embeddings_model = None
                 await log_stream.put(
-                    f"WARNING: Failed to initialize OpenRouter embeddings: {e}"
+                    f"WARNING: Failed to initialize {provider_label} embeddings: {e}"
                 )
 
         elif provider == "llamacpp":
@@ -2493,7 +2502,7 @@ async def build_and_run_graph(payload: dict = Body(...)):
         else:
             return JSONResponse(
                 content={
-                    "message": "Invalid provider. Please select openrouter or llamacpp."
+                    "message": "Invalid provider. Please select openrouter, requesty or llamacpp."
                 },
                 status_code=400,
             )
@@ -2501,12 +2510,12 @@ async def build_and_run_graph(payload: dict = Body(...)):
         # Create synthesis LLM if user specified a different model for synthesis
         synthesis_llm = llm
         if synthesis_model and synthesis_model != default_agent_model:
-            if provider == "openrouter":
+            if provider in ("openrouter", "requesty"):
                 try:
                     synthesis_llm = ChatOpenAI(
                         model=synthesis_model,
                         openai_api_key=api_key,
-                        openai_api_base="https://openrouter.ai/api/v1",
+                        openai_api_base=cloud_api_base,
                         temperature=0.7,
                         callbacks=[token_tracker],
                     )
@@ -2940,12 +2949,12 @@ Your Specialty is: {persona.get("specialty", "Analysis")}.
             model_for_this_agent = effective_models[m_idx]
             if is_debug:
                 per_agent_llm = CoderMockLLM()
-            elif provider == "openrouter":
+            elif provider in ("openrouter", "requesty"):
                 try:
                     per_agent_llm = ChatOpenAI(
                         model=model_for_this_agent,
                         openai_api_key=api_key,
-                        openai_api_base="https://openrouter.ai/api/v1",
+                        openai_api_base=cloud_api_base,
                         temperature=0.7,
                         callbacks=[token_tracker],
                     )
@@ -3682,6 +3691,13 @@ async def start_distillation(payload: dict = Body(...)):
     provider = payload.get("provider", "openrouter")
     api_key = payload.get("api_key", "")
 
+    # Base URL for the selected OpenAI-compatible cloud provider (OpenRouter / Requesty)
+    cloud_api_base = (
+        "https://router.requesty.ai/v1"
+        if provider == "requesty"
+        else "https://openrouter.ai/api/v1"
+    )
+
     await log_stream.put(
         f"--- ⚗️ DISTILLATION: Initializing (provider: {provider}, debug: {debug_mode}) ---"
     )
@@ -3697,23 +3713,24 @@ async def start_distillation(payload: dict = Body(...)):
             distil_model = (
                 payload.get("synthesis_model", "").strip()
                 or payload.get("openrouter_model", "stepfun/step-3.5-flash:free")
-                if provider == "openrouter"
+                if provider in ("openrouter", "requesty")
                 else payload.get("llamacpp_model", "llama-3.2-1b-instruct")
             )
-            if provider == "openrouter":
+            if provider in ("openrouter", "requesty"):
+                provider_label = "Requesty" if provider == "requesty" else "OpenRouter"
                 if not api_key:
                     return JSONResponse(
-                        content={"message": "OpenRouter API Key required"},
+                        content={"message": f"{provider_label} API Key required"},
                         status_code=400,
                     )
                 llm = ChatOpenAI(
                     model=distil_model,
                     openai_api_key=api_key,
-                    openai_api_base="https://openrouter.ai/api/v1",
+                    openai_api_base=cloud_api_base,
                     temperature=0.7,
                 )
                 await log_stream.put(
-                    f"--- Distillation LLM: OpenRouter ({distil_model}) ---"
+                    f"--- Distillation LLM: {provider_label} ({distil_model}) ---"
                 )
             elif provider == "llamacpp":
                 llamacpp_url = payload.get("llamacpp_url", "http://localhost:8080/v1")
@@ -3734,7 +3751,7 @@ async def start_distillation(payload: dict = Body(...)):
             else:
                 return JSONResponse(
                     content={
-                        "message": "Invalid provider. Please select openrouter or llamacpp."
+                        "message": "Invalid provider. Please select openrouter, requesty or llamacpp."
                     },
                     status_code=400,
                 )

--- a/index.html
+++ b/index.html
@@ -23,14 +23,15 @@
             <label for="llm-provider">🤖 LLM Provider</label>
             <select id="llm-provider">
                 <option value="openrouter">OpenRouter</option>
+                <option value="requesty">Requesty</option>
                 <option value="llamacpp">LlamaCpp Server</option>
             </select>
 
             <div id="openrouter-config" class="provider-config">
                 <label for="openrouter-api-key">🔗 API Key</label>
-                <input type="password" id="openrouter-api-key" placeholder="OpenRouter API key...">
+                <input type="password" id="openrouter-api-key" placeholder="OpenRouter / Requesty API key...">
                 <label for="openrouter-model">📦 Model</label>
-                <input type="text" id="openrouter-model" value="stepfun/step-3.5-flash:free" placeholder="model-name">
+                <input type="text" id="openrouter-model" value="stepfun/step-3.5-flash:free" placeholder="provider/model">
             </div>
 
             <div id="llamacpp-config" class="provider-config">
@@ -703,7 +704,7 @@
                 const agentMdls = document.getElementById('agent-models') ? document.getElementById('agent-models').value.trim() : '';
 
                 let api_key = '';
-                if (provider === 'openrouter') api_key = openrouterKey;
+                if (provider === 'openrouter' || provider === 'requesty') api_key = openrouterKey;
 
                 const startBtn = document.getElementById('start-distillation-btn');
                 const stopBtn = document.getElementById('stop-distillation-btn');
@@ -1089,11 +1090,11 @@
         if (savedAgentModels) document.getElementById('agent-models').value = savedAgentModels;
 
 
-        // Show/hide config based on provider (only openrouter / llamacpp)
+        // Show/hide config based on provider (openrouter / requesty share the cloud config, or llamacpp)
         const updateProviderConfig = () => {
             openrouterConfig.classList.remove('is-visible');
             llamacppConfig.classList.remove('is-visible');
-            if (llmProviderSelect.value === 'openrouter') {
+            if (llmProviderSelect.value === 'openrouter' || llmProviderSelect.value === 'requesty') {
                 openrouterConfig.classList.add('is-visible');
             } else if (llmProviderSelect.value === 'llamacpp') {
                 llamacppConfig.classList.add('is-visible');
@@ -1181,8 +1182,8 @@
                     const llamacppModel = localStorage.getItem('llamacpp_model') || 'llama-3.2-1b-instruct';
 
 
-                    if (provider === 'openrouter' && !openrouterApiKey) {
-                        alert('Please save your OpenRouter API key in the settings panel first.');
+                    if ((provider === 'openrouter' || provider === 'requesty') && !openrouterApiKey) {
+                        alert('Please save your OpenRouter / Requesty API key in the settings panel first.');
                         chat.finishStreaming();
                         return;
                     }
@@ -1578,7 +1579,7 @@
             const agentMdls = document.getElementById('agent-models') ? document.getElementById('agent-models').value.trim() : '';
 
             params.provider = provider;
-            if (provider === 'openrouter') params.api_key = openrouterKey;
+            if (provider === 'openrouter' || provider === 'requesty') params.api_key = openrouterKey;
 
             params.openrouter_model = openrouterMdl;
             params.llamacpp_url = llamacppServerUrl;


### PR DESCRIPTION
## Add Requesty as an OpenAI-compatible provider

This adds [Requesty](https://requesty.ai) as a selectable provider, mirroring the existing OpenRouter integration.

Requesty is an OpenAI-compatible model gateway that uses the same `provider/model` identifier format as OpenRouter and the same Bearer-key auth, so it shares OpenRouter's key/model fields and differs only by base URL (`https://router.requesty.ai/v1`). It is wired as a sibling of the existing OpenRouter provider rather than a separate code path.

### Changes
- `app.py` — provider-aware `cloud_api_base` (Requesty base URL when `provider == "requesty"`, else OpenRouter); broaden the `provider == "openrouter"` checks to `provider in ("openrouter", "requesty")` across the main LLM, embeddings, synthesis LLM, and per-agent LLM init sites; provider-aware log/error labels; updated the invalid-provider message.
- `index.html` — add `<option value="requesty">Requesty</option>`, relabel the shared cloud config panel, and broaden the JS provider guards.
- `README.md` — list Requesty as a supported provider.

### Testing
- `python -m py_compile app.py` passes.
- Live endpoint: `POST https://router.requesty.ai/v1/chat/completions` with `model: openai/gpt-4o-mini` -> HTTP 200, real completion.

### Disclosure
I work at Requesty. This mirrors the existing OpenRouter wiring as closely as possible and adds no new dependencies. Happy to adjust naming/placement or close it if it's not a fit.
