### PR TITLE
feat: copy button on system chat answers (v0.2.1)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+# Release Notes — `0.2.1`
+
+**Tag:** `0.2.1`
+**Date:** 2026-08-13
+**Tagline:** "Copy system answers from the chatbox"
+
+### Chat UI
+* Each completed system (assistant) reply in NodeChat now has a **Copy** button
+* Copies the original markdown/text of the answer (not the rendered HTML)
+* Button appears after the reply finishes — streaming updates do not wipe it
+* Clipboard API with `execCommand` fallback; brief Copied / failed feedback
+
+---
+
 # Release Notes — `0.2.0`
 
 **Tag:** `0.2.0`

--- a/css/node-chat.css
+++ b/css/node-chat.css
@@ -606,6 +606,60 @@
   border-bottom-left-radius: 0.25rem;
 }
 
+/* AI answer row: bubble + copy control (copy sits outside innerHTML so streaming is safe) */
+.nc-msg-row--ai {
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  max-width: 80%;
+  position: relative;
+  z-index: 1;
+  gap: 0.35rem;
+}
+
+.nc-msg-row--ai .nc-msg {
+  max-width: 100%;
+}
+
+.nc-copy-btn {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.35);
+  border: 1px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: color 0.2s, background 0.2s, border-color 0.2s;
+}
+
+.nc-copy-btn:hover {
+  color: rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.nc-copy-btn:focus-visible {
+  outline: 1px solid rgba(139, 92, 246, 0.6);
+  outline-offset: 2px;
+}
+
+.nc-copy-btn.is-copied {
+  color: #86efac;
+}
+
+.nc-copy-btn.is-error {
+  color: #fca5a5;
+}
+
+.nc-copy-btn[hidden] {
+  display: none;
+}
+
 /* markdown content inside ai messages */
 .nc-msg--ai h1,
 .nc-msg--ai h2,
@@ -845,7 +899,8 @@
     padding: 0.75rem 1rem;
   }
 
-  .nc-msg {
+  .nc-msg,
+  .nc-msg-row--ai {
     max-width: 90%;
   }
 

--- a/deepthink/__init__.py
+++ b/deepthink/__init__.py
@@ -23,9 +23,9 @@ from __future__ import annotations
 
 from typing import Any
 
-__version__ = "0.2.0"
-__release_name__ = "library-api"
-__release_tag__ = "0.2.0"
+__version__ = "0.2.1"
+__release_name__ = "copy-answers"
+__release_tag__ = "0.2.1"
 
 # Lightweight imports — always safe, no LangChain graph spin-up
 from deepthink.state import BRAINSTORM_EXPERTS, GraphState

--- a/js/components/node-chat.js
+++ b/js/components/node-chat.js
@@ -47,6 +47,32 @@ const NodeChat = (() => {
         trash: `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14a2 2 0 01-2 2H9a2 2 0 01-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a1 1 0 011-1h4a1 1 0 011 1v2"/></svg>`,
         refresh: `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 11-2.12-9.36L23 10"/></svg>`,
         brain: `<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a7 7 0 00-7 7c0 3 2 5.5 4 7.5S12 22 12 22s3-3.5 5-5.5 4-4.5 4-7.5a7 7 0 00-7-7z"/></svg>`,
+        copy: `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>`,
+        check: `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>`,
+    };
+
+    const copyToClipboard = async (text) => {
+        if (!text) return false;
+        try {
+            if (navigator.clipboard && window.isSecureContext) {
+                await navigator.clipboard.writeText(text);
+                return true;
+            }
+        } catch (_) { /* fall through to execCommand */ }
+        try {
+            const ta = document.createElement('textarea');
+            ta.value = text;
+            ta.setAttribute('readonly', '');
+            ta.style.position = 'fixed';
+            ta.style.left = '-9999px';
+            document.body.appendChild(ta);
+            ta.select();
+            const ok = document.execCommand('copy');
+            document.body.removeChild(ta);
+            return ok;
+        } catch (_) {
+            return false;
+        }
     };
 
     /* ============================================================
@@ -328,12 +354,42 @@ const NodeChat = (() => {
             scrollToBottom(messagesArea);
         }
 
-        function addAIBubble() {
+        function addAIBubble({ ready = false, text = '' } = {}) {
             clearEmpty();
-            const bubble = h('div', { className: 'nc-msg nc-msg--ai' });
-            messagesArea.appendChild(bubble);
+            const content = h('div', { className: 'nc-msg nc-msg--ai' });
+            const copyBtn = h('button', {
+                className: 'nc-copy-btn',
+                type: 'button',
+                title: 'Copy answer',
+            });
+            copyBtn.setAttribute('aria-label', 'Copy answer');
+            copyBtn.innerHTML = icons.copy;
+            copyBtn.hidden = !ready;
+
+            const row = h('div', { className: 'nc-msg-row nc-msg-row--ai' }, content, copyBtn);
+            row._copyText = text;
+            row._copyBtn = copyBtn;
+
+            copyBtn.addEventListener('click', async () => {
+                const payload = row._copyText || '';
+                if (!payload) return;
+                const ok = await copyToClipboard(payload);
+                copyBtn.classList.toggle('is-copied', ok);
+                copyBtn.classList.toggle('is-error', !ok);
+                copyBtn.innerHTML = ok ? icons.check : icons.copy;
+                copyBtn.title = ok ? 'Copied' : 'Copy failed';
+                copyBtn.setAttribute('aria-label', copyBtn.title);
+                setTimeout(() => {
+                    copyBtn.classList.remove('is-copied', 'is-error');
+                    copyBtn.innerHTML = icons.copy;
+                    copyBtn.title = 'Copy answer';
+                    copyBtn.setAttribute('aria-label', 'Copy answer');
+                }, 1600);
+            });
+
+            messagesArea.appendChild(row);
             scrollToBottom(messagesArea);
-            return bubble;
+            return content;
         }
 
         function addThinking() {
@@ -382,16 +438,18 @@ const NodeChat = (() => {
                     await opts.onSend(text, chatAPI);
                 } catch (err) {
                     removeThinking();
-                    const errBubble = addAIBubble();
-                    errBubble.innerHTML = `<span style="color:#ef4444">Error: ${err.message}</span>`;
+                    const errText = `Error: ${err.message}`;
+                    const errBubble = addAIBubble({ ready: true, text: errText });
+                    errBubble.innerHTML = `<span style="color:#ef4444">${errText}</span>`;
                 }
             } else {
                 // Default: echo back after 1s (demo)
                 setTimeout(() => {
                     removeThinking();
-                    const bubble = addAIBubble();
-                    bubble.innerHTML = renderMarkdown(`You said: **${text}**\n\nConnect an \`onSend\` handler to make this functional.`);
-                    finishStreaming();
+                    const demo = `You said: **${text}**\n\nConnect an \`onSend\` handler to make this functional.`;
+                    const bubble = addAIBubble({ ready: true, text: demo });
+                    bubble.innerHTML = renderMarkdown(demo);
+                    finishStreaming(demo);
                 }, 1000);
             }
         }
@@ -406,6 +464,8 @@ const NodeChat = (() => {
 
         function updateAIResponse(bubble, fullText) {
             bubble.innerHTML = renderMarkdown(fullText);
+            const row = bubble && bubble.parentElement;
+            if (row) row._copyText = fullText;
             scrollToBottom(messagesArea);
         }
 
@@ -416,13 +476,19 @@ const NodeChat = (() => {
             if (content) {
                 state.messages.push({ role: 'assistant', content });
             }
+            const rows = messagesArea.querySelectorAll('.nc-msg-row--ai');
+            const last = rows[rows.length - 1];
+            if (last && last._copyBtn) {
+                if (typeof content === 'string') last._copyText = content;
+                last._copyBtn.hidden = !last._copyText;
+            }
         }
 
         function appendAIMessage(text) {
             // For SSE-style: add a complete message at once
             clearEmpty();
             removeThinking();
-            const bubble = addAIBubble();
+            const bubble = addAIBubble({ ready: true, text });
             bubble.innerHTML = renderMarkdown(text);
             state.messages.push({ role: 'assistant', content: text });
             state.isStreaming = false;

--- a/tests/phase10_static.py
+++ b/tests/phase10_static.py
@@ -148,6 +148,23 @@ def t7():
 chk("js/components/node-chat.js exists", t7)
 
 
+# 7b) System answers expose a copy button that is not inside streamed innerHTML
+def t7b():
+    js_path = ROOT.joinpath("js", "components", "node-chat.js")
+    css_path = ROOT.joinpath("css", "node-chat.css")
+    js = js_path.read_text(encoding="utf-8")
+    css = css_path.read_text(encoding="utf-8")
+    assert "nc-copy-btn" in js
+    assert "copyToClipboard" in js
+    assert "nc-msg-row--ai" in js
+    assert "navigator.clipboard" in js
+    assert "nc-copy-btn" in css
+    assert "nc-msg-row--ai" in css
+
+
+chk("NodeChat system answers have a copy button", t7b)
+
+
 # 8) Env template exists; optional local .env for secrets (gitignored)
 def t8():
     has_env = os.path.exists(str(ROOT.joinpath(".env")))


### PR DESCRIPTION
## Summary

Adds a **Copy** button under each completed system (assistant) reply in the NodeChat chatbox.

- Copies the original markdown/text, not rendered HTML
- Button sits outside streamed `innerHTML` so diagnostic streaming cannot wipe it
- Appears after the reply finishes; clipboard API with `execCommand` fallback
- Version bump to `0.2.1` (`copy-answers`)

## Test plan

- [x] `python tests/phase10_static.py` (28/28)
- [ ] Start a brainstorm / diagnostic chat and copy a finished system answer
- [ ] Confirm the button is hidden while a reply is still streaming

Tag `0.2.1` already points at this commit; release will be published after merge.