### PR TITLE
fix: single-engine QNN, parallel layers, hardened sandbox (v0.2.2)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,22 @@
+# Release Notes — `0.2.2`
+
+**Tag:** `0.2.2`
+**Date:** 2026-08-13
+**Tagline:** "Single-engine QNN + hardened runtime"
+
+### Engine
+* Brainstorm UI now runs `deepthink.qnn.run_qnn_pipeline` — same engine as the library API and `/qnn` skill
+* QNN forward pass, persona span, and Mirror Descent are parallel per layer (`asyncio.gather`)
+* Manual / massive topologies are no longer silently capped at 60 agents
+
+### Runtime
+* `execute_code_in_sandbox` is AST-gated and runs in an isolated subprocess with a timeout (duplicate copy removed from `app.py`)
+* Distillation token accounting uses tiktoken when available
+* Distillation LLM JSON is parsed through `parse_llm_json` instead of raw `json.loads`
+* Mirror Descent evaluations in distillation run concurrently
+
+---
+
 # Release Notes — `0.2.1`
 
 **Tag:** `0.2.1`

--- a/app.py
+++ b/app.py
@@ -73,6 +73,7 @@ from deepthink.chains import (
     get_brainstorming_epoch_map_chain,
 )
 from deepthink.qdad import run_qdad_pipeline
+from deepthink.qnn import run_qnn_pipeline
 from deepthink.knowledge_distillation import DistillationGraph
 from deepthink.utils import clean_and_parse_json, execute_code_in_sandbox
 from deepthink.self_attention import compute_self_attention
@@ -1358,48 +1359,6 @@ class GraphState(TypedDict):
     attention_edges: Annotated[dict, lambda a, b: {**a, **b}]
 
 
-def execute_code_in_sandbox(code: str) -> (bool, str):
-    """
-    Executes a string of Python code and captures its stdout/stderr.
-    Returns a tuple of (success: bool, output: str).
-    """
-    if not code:
-        return True, "No code to execute."
-
-    # Extract code from markdown block if present
-    code_match = re.search(r"```(?:python\n)?([\s\S]*?)```", code)
-    if code_match:
-        code = code_match.group(1).strip()
-
-    output_buffer = io.StringIO()
-    try:
-        with redirect_stdout(output_buffer), redirect_stderr(output_buffer):
-            # Using a restricted globals dict for a little more safety
-            exec(
-                code,
-                {
-                    "__builtins__": {
-                        "print": print,
-                        "range": range,
-                        "len": len,
-                        "str": str,
-                        "int": int,
-                        "float": float,
-                        "list": list,
-                        "dict": dict,
-                        "set": set,
-                        "tuple": tuple,
-                        "True": True,
-                        "False": False,
-                        "None": None,
-                    }
-                },
-            )
-        return True, output_buffer.getvalue()
-    except Exception as e:
-        return False, f"{output_buffer.getvalue()}\n\nERROR: {type(e).__name__}: {e}"
-
-
 def create_agent_node(llm, node_id):
     """
     Creates a node in the graph that represents an agent.
@@ -2656,6 +2615,37 @@ async def run_inference_from_state(payload: dict = Body(...)):
         )
 
 
+async def run_qnn_background(
+    llm,
+    synthesis_llm,
+    params,
+    user_prompt: str,
+    session_id: str,
+    document_context: str = "",
+    chat_history=None,
+):
+    """
+    Brainstorm background runner.
+
+    Delegates to deepthink.qnn.run_qnn_pipeline (same engine as the /qnn skill).
+    """
+
+    async def _log(msg: str):
+        await log_stream.put(msg)
+
+    await run_qnn_pipeline(
+        llm=llm,
+        user_prompt=user_prompt or "",
+        params=params or {},
+        synthesis_llm=synthesis_llm or llm,
+        document_context=document_context or "",
+        chat_history=chat_history or [],
+        log=_log,
+        session_id=session_id,
+        session_store=sessions,
+    )
+
+
 async def run_qdad_background(
     llm,
     synthesis_llm,
@@ -2963,6 +2953,47 @@ async def build_and_run_graph(payload: dict = Body(...)):
                 llamacpp_url=llamacpp_url,
                 llamacpp_api_key=llamacpp_api_key,
                 token_tracker=token_tracker,
+            )
+        )
+        return JSONResponse(
+            content={"message": "Graph started.", "session_id": session_id}
+        )
+
+    # ── Brainstorm (QNN): same library engine as `deepthink qnn` / /qnn skill ──
+    if mode == "brainstorm":
+        session_id = str(uuid.uuid4())
+        sessions[session_id] = {
+            "session_id": session_id,
+            "mode": "brainstorm",
+            "original_request": user_prompt,
+            "params": params,
+            "final_solution": None,
+            "all_rag_documents": [],
+            "all_layers_prompts": [],
+            "agent_personas": {},
+            "agent_outputs": {},
+            "memory": {},
+            "epoch": 0,
+            "max_epochs": int(params.get("num_epochs", 2) or 2),
+            "raptor_index": None,
+            "attention_edges": {},
+        }
+        await log_stream.put(f"__session_id__ {session_id}")
+        await log_stream.put(
+            "__start__ QNN Brainstorm\n"
+            "  Brief → Topology → Seeds → Personas\n"
+            "  → Epochs (forward / map / Mirror Descent / reframe)\n"
+            "  → Solution-Space Report"
+        )
+        asyncio.create_task(
+            run_qnn_background(
+                llm=llm,
+                synthesis_llm=synthesis_llm,
+                params=params,
+                user_prompt=user_prompt or "",
+                session_id=session_id,
+                document_context=document_context or "",
+                chat_history=payload.get("chat_history", []) or [],
             )
         )
         return JSONResponse(

--- a/deepthink/__init__.py
+++ b/deepthink/__init__.py
@@ -23,9 +23,9 @@ from __future__ import annotations
 
 from typing import Any
 
-__version__ = "0.2.1"
-__release_name__ = "copy-answers"
-__release_tag__ = "0.2.1"
+__version__ = "0.2.2"
+__release_name__ = "single-engine"
+__release_tag__ = "0.2.2"
 
 # Lightweight imports — always safe, no LangChain graph spin-up
 from deepthink.state import BRAINSTORM_EXPERTS, GraphState

--- a/deepthink/api.py
+++ b/deepthink/api.py
@@ -62,6 +62,7 @@ async def run_qnn(
     chat_history: list[dict] | None = None,
     log: LogFn = None,
     session_id: str = "",
+    session_store: dict | None = None,
 ) -> dict[str, Any]:
     """
     Run a Qualitative Neural Network (brainstorm / solution-space) pipeline.
@@ -77,6 +78,7 @@ async def run_qnn(
         chat_history=chat_history,
         log=log,
         session_id=session_id,
+        session_store=session_store,
     )
 
 

--- a/deepthink/knowledge_distillation.py
+++ b/deepthink/knowledge_distillation.py
@@ -14,6 +14,7 @@ from deepthink.chains import (
     get_followup_question_chain,
     DISTILLATION_ARCHETYPES,
 )
+from deepthink.utils import estimate_tokens, parse_llm_json
 
 # PerplexityChain lives in its own module (used only by distillation mode for LLM-based quality scoring).
 # We import it here so the _compute_perplexity method can actually find the name.
@@ -160,8 +161,8 @@ class DistillationGraph:
 
     @staticmethod
     def _estimate_tokens(text: str) -> int:
-        """Rough estimate: 1 token ≈ 4 characters."""
-        return len(text) // 4
+        """Token count via tiktoken when available, else ~4 chars/token."""
+        return estimate_tokens(text)
 
     def _count_tokens(self, input_text: str, output_text: str):
         """Track input and output tokens separately."""
@@ -301,7 +302,6 @@ class DistillationGraph:
         await self._step_seed_and_followup(flat_agents)
 
         # ── Write dataset to file in real-time ──
-        # ── Write dataset to file in real-time ──
         self._write_dataset_to_file()
 
         # ── Calculate Perplexity (Quality Metric) ──
@@ -362,7 +362,7 @@ class DistillationGraph:
                 }
             )
             self._count_tokens(input_text, result)
-            parsed = json.loads(result)
+            parsed = parse_llm_json(result)
             return parsed.get("sub_questions", [f"Sub-question {i}" for i in range(12)])
         except Exception as e:
             await self.log(f"Task Master error: {e}")
@@ -485,12 +485,18 @@ Be thorough and analytical.
         current_grid_description = self._build_current_grid_description()
         await self.log(f"DISTILLATION_LOG: 📋 Current Grid Snapshot:\n{current_grid_description}")
 
-        for agent in flat_agents:
+        evals = await asyncio.gather(
+            *[self._evaluate_agent(agent, current_grid_description) for agent in flat_agents],
+            return_exceptions=True,
+        )
+
+        for agent, eval_result in zip(flat_agents, evals):
             if not self.is_running:
                 return
 
             try:
-                eval_result = await self._evaluate_agent(agent, current_grid_description)
+                if isinstance(eval_result, Exception):
+                    raise eval_result
                 difficulty = eval_result.get("difficulty", "Easy")
                 agent.difficulty_history.append(difficulty)
 
@@ -526,7 +532,7 @@ Be thorough and analytical.
         input_text = json.dumps(input_data)
         result_json = await chain.ainvoke(input_data)
         self._count_tokens(input_text, result_json)
-        return json.loads(result_json)
+        return parse_llm_json(result_json)
 
     async def _handle_hard_agent(
         self, agent: DistillationAgent, eval_result: dict, flat_agents: List[DistillationAgent]
@@ -593,7 +599,7 @@ Be thorough and analytical.
         input_text = json.dumps(input_data)
         result_json = await chain.ainvoke(input_data)
         self._count_tokens(input_text, result_json)
-        return json.loads(result_json)
+        return parse_llm_json(result_json)
 
     # ------------------------------------------------------------------
     # STEP 4: SYNTHESIZE FINAL ANSWER
@@ -672,7 +678,7 @@ Be thorough and analytical.
         try:
             result = await chain.ainvoke(input_data)
             self._count_tokens(input_text, result)
-            return json.loads(result).get("new_topics", self.topics)
+            return parse_llm_json(result).get("new_topics", self.topics)
         except Exception as e:
             await self.log(f"Seed Creator error: {e}")
             await self.log(f"DISTILLATION_LOG: ❌ Seed Creator failed: {e}")
@@ -692,7 +698,7 @@ Be thorough and analytical.
         try:
             result = await chain.ainvoke(input_data)
             self._count_tokens(input_text, result)
-            return json.loads(result).get("new_questions", [])
+            return parse_llm_json(result).get("new_questions", [])
         except Exception as e:
             await self.log(f"Followup error: {e}")
             return []

--- a/deepthink/qnn/pipeline.py
+++ b/deepthink/qnn/pipeline.py
@@ -8,28 +8,28 @@ mocks, etc.). Used by the open-deepthink Brainstorm UI *and* the portable
 
 from __future__ import annotations
 
+import asyncio
 import json
 import random
-import traceback
 from dataclasses import asdict, dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
-from deepthink.utils import clean_and_parse_json
-from deepthink.self_attention import compute_self_attention
-from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
 
 from deepthink.chains.brainstorm_chains import (
-    get_complexity_estimator_chain,
+    get_brainstorming_epoch_map_chain,
+    get_brainstorming_mirror_descent_chain,
+    get_brainstorming_polisher_chain,
+    get_brainstorming_reframer_chain,
     get_brainstorming_seed_chain,
     get_brainstorming_spanner_chain,
-    get_brainstorming_mirror_descent_chain,
-    get_brainstorming_reframer_chain,
-    get_brainstorming_epoch_map_chain,
     get_brainstorming_synthesis_chain,
-    get_brainstorming_polisher_chain,
+    get_complexity_estimator_chain,
     get_problem_summarizer_chain,
 )
+from deepthink.self_attention import compute_self_attention
+from deepthink.utils import clean_and_parse_json
 
 
 LogFn = Optional[Callable[[str], Any]]
@@ -77,14 +77,167 @@ async def _log(log: LogFn, msg: str) -> None:
         await result
 
 
-def _clamp_topology(layers: int, width: int, epochs: int) -> tuple:
-    layers = max(1, min(20, int(layers)))
-    width = max(1, min(20, int(width)))
-    epochs = max(1, min(10, int(epochs)))
-    # Soft budget unless caller already chose manual large
-    if layers * width > 60:
+def _clamp_topology(
+    layers: int, width: int, epochs: int, *, manual: bool = False
+) -> tuple:
+    """Bound topology. Auto mode keeps a 60-agent soft cap; manual/massive does not."""
+    layers = max(1, min(100, int(layers)))
+    width = max(1, min(100, int(width)))
+    epochs = max(1, min(20, int(epochs)))
+    if not manual and layers * width > 60:
         width = max(1, 60 // layers)
     return layers, width, epochs
+
+
+def _persist_session(session_store, session_id: str, payload: Dict[str, Any]) -> None:
+    if session_store is None or not session_id or session_id not in session_store:
+        return
+    session_store[session_id].update(payload)
+
+
+async def _span_persona(spanner, user_prompt: str, guiding_words: str, i: int, j: int, brief: str):
+    raw = await spanner.ainvoke(
+        {
+            "problem": user_prompt,
+            "guiding_words": guiding_words,
+            "layer_index": i,
+            "node_index": j,
+            "document_context": brief,
+        }
+    )
+    persona = clean_and_parse_json(raw) or {}
+    if not isinstance(persona, dict):
+        persona = {}
+    system_prompt = persona.get("system_prompt") or (
+        f"You are a QNN expert spanned from: {guiding_words}. "
+        f"Layer {i} ({'diverge' if i == 0 else 'converge'}). Map strategies with falsifiers."
+    )
+    persona.setdefault("name", f"Agent_{i}_{j}")
+    persona.setdefault("specialty", "Word-vector specialist")
+    persona.setdefault("guiding_words", guiding_words)
+    persona["system_prompt"] = system_prompt
+    return f"agent_{i}_{j}", persona, system_prompt
+
+
+async def _run_agent_cell(
+    agent_chain,
+    *,
+    node_id: str,
+    layer_index: int,
+    persona: Dict[str, Any],
+    brief: str,
+    user_prompt: str,
+    current_problem: str,
+    epoch: int,
+    prev_layer_outputs: List[Any],
+    memory: Dict[str, List[Any]],
+    agent_outputs_snapshot: Dict[str, Any],
+    all_layers_prompts: List[List[str]],
+    agent_personas: Dict[str, Any],
+    enable_attn: bool,
+    top_k: int,
+    log: LogFn,
+) -> tuple:
+    agent_prompt = (
+        f"YOU ARE {str(persona.get('name', 'Expert')).upper()}, "
+        f"A {str(persona.get('specialty', 'Specialist')).upper()}.\n\n"
+        f"{persona.get('system_prompt', '')}"
+    )
+
+    attention_block = ""
+    edge_dicts: List[dict] = []
+    if enable_attn and top_k > 0:
+        state_snap = {
+            "epoch": epoch,
+            "all_layers_prompts": all_layers_prompts,
+            "agent_personas": agent_personas,
+            "agent_outputs": agent_outputs_snapshot,
+            "memory": memory,
+        }
+        try:
+            edges, attention_block = compute_self_attention(
+                state_snap, node_id, top_k=top_k
+            )
+            if edges:
+                edge_dicts = [e.to_dict() for e in edges]
+                await _log(
+                    log,
+                    f"LOG: [QNN ATTEND] {node_id} → "
+                    + ", ".join(f"{e.to_id}({e.strength})" for e in edges),
+                )
+        except Exception as ae:
+            await _log(log, f"WARNING: [QNN ATTEND] {node_id}: {ae}")
+
+    if layer_index == 0:
+        input_data = f"""## QNN Brief
+{brief}
+
+## Original Request (ground truth — do not replace)
+{user_prompt}
+
+## Thinking Challenge (epoch {epoch})
+{current_problem}
+
+## Layer 0 Role
+Divergent exploration. Span strategies and mechanisms. Do NOT write production patches.
+
+{attention_block}
+"""
+    else:
+        input_data = f"""## QNN Brief
+{brief}
+
+## Original Request (ground truth — do not replace)
+{user_prompt}
+
+## Thinking Challenge (epoch {epoch})
+{current_problem}
+
+## Layer {layer_index} Role
+Convergent / critical. Critique or combine upstream. Cite agent_id. No production patches.
+
+## Upstream Layer Outputs (graph neighbors)
+{json.dumps(prev_layer_outputs, indent=2)}
+
+{attention_block}
+"""
+
+    mem_str = "\n".join(f"- {json.dumps(m)}" for m in memory.get(node_id, [])[-5:])
+    full_prompt = f"""
+#System Prompt (Your Persona & Task):
+---
+{agent_prompt}
+---
+#Your Memory (Past Actions):
+---
+{mem_str or "No past actions."}
+---
+#Input Data to Process:
+---
+{input_data}
+---
+# Your JSON response (required keys):
+{{
+  "original_problem": "<brief or challenge you addressed>",
+  "proposed_solution": "<strategic angle / mechanism — NOT a production patch>",
+  "reasoning": "<why this might break the impasse>",
+  "falsifiers": "<evidence that would kill this angle>",
+  "risks": "<ways it could fail>",
+  "skills_used": []
+}}
+"""
+    raw_out = await agent_chain.ainvoke({"input": full_prompt})
+    parsed = clean_and_parse_json(raw_out)
+    if not isinstance(parsed, dict):
+        parsed = {
+            "original_problem": current_problem,
+            "proposed_solution": str(raw_out)[:2000],
+            "reasoning": "unparsed agent output",
+            "falsifiers": "",
+            "risks": "",
+            "skills_used": [],
+        }
+    return node_id, parsed, edge_dicts
 
 
 async def run_qnn_pipeline(
@@ -97,6 +250,7 @@ async def run_qnn_pipeline(
     chat_history: Optional[List[dict]] = None,
     log: LogFn = None,
     session_id: str = "",
+    session_store: Optional[dict] = None,
 ) -> Dict[str, Any]:
     """
     Run the full Qualitative Neural Network (brainstorm) pipeline.
@@ -127,6 +281,8 @@ async def run_qnn_pipeline(
         Optional ``async/sync (str) -> None`` callback for progress lines.
     session_id : str
         Opaque id for callers that persist sessions.
+    session_store : dict, optional
+        Optional ``{session_id: state}`` map updated in place (web UI).
 
     Returns
     -------
@@ -166,8 +322,9 @@ async def run_qnn_pipeline(
     qnn_mode = str(p.get("qnn_mode", "auto")).lower()
     epochs = max(1, int(p.get("num_epochs", 2)))
     layers, width = 2, 3
+    manual = qnn_mode == "manual"
 
-    if qnn_mode == "manual":
+    if manual:
         layers = int(p.get("manual_layers", 3))
         width = int(p.get("manual_width", 3))
         await _log(
@@ -197,7 +354,7 @@ async def run_qnn_pipeline(
             await _log(log, f"WARNING: complexity estimator failed ({e}); defaults.")
             layers, width, epochs = 2, 3, 2
 
-    layers, width, epochs = _clamp_topology(layers, width, epochs)
+    layers, width, epochs = _clamp_topology(layers, width, epochs, manual=manual)
     V = max(2, int(p.get("vector_word_size", 6)))
     top_k = max(0, int(p.get("attention_top_k", 5)))
     enable_attn = bool(p.get("enable_self_attention", True))
@@ -254,36 +411,21 @@ async def run_qnn_pipeline(
         column_guiding_words.append(" ".join(sample))
         await _log(log, f"LOG: [QNN STEP 2] Column {j} guiding_words: {column_guiding_words[-1]}")
 
-    # ── Step 3: Span personas ──────────────────────────────────────
+    # ── Step 3: Span personas (parallel per layer) ─────────────────
     await _log(log, f"LOG: [QNN STEP 3] Spanning {layers}×{width} personas...")
     spanner = get_brainstorming_spanner_chain(llm)
     agent_personas: Dict[str, Any] = {}
     all_layers_prompts: List[List[str]] = []
 
     for i in range(layers):
+        spanned = await asyncio.gather(
+            *[
+                _span_persona(spanner, user_prompt, column_guiding_words[j], i, j, brief)
+                for j in range(width)
+            ]
+        )
         layer_prompts: List[str] = []
-        for j in range(width):
-            node_id = f"agent_{i}_{j}"
-            raw = await spanner.ainvoke(
-                {
-                    "problem": user_prompt,
-                    "guiding_words": column_guiding_words[j],
-                    "layer_index": i,
-                    "node_index": j,
-                    "document_context": brief,
-                }
-            )
-            persona = clean_and_parse_json(raw) or {}
-            if not isinstance(persona, dict):
-                persona = {}
-            system_prompt = persona.get("system_prompt") or (
-                f"You are a QNN expert spanned from: {column_guiding_words[j]}. "
-                f"Layer {i} ({'diverge' if i == 0 else 'converge'}). Map strategies with falsifiers."
-            )
-            persona.setdefault("name", f"Agent_{i}_{j}")
-            persona.setdefault("specialty", "Word-vector specialist")
-            persona.setdefault("guiding_words", column_guiding_words[j])
-            persona["system_prompt"] = system_prompt
+        for node_id, persona, system_prompt in spanned:
             agent_personas[node_id] = persona
             layer_prompts.append(system_prompt)
             await _log(
@@ -301,132 +443,92 @@ async def run_qnn_pipeline(
 
     agent_chain = ChatPromptTemplate.from_template("{input}") | llm | StrOutputParser()
 
+    def _build_result(report: str, epoch: int, reasoning: str) -> Dict[str, Any]:
+        final = {
+            "mode": "brainstorm",
+            "proposed_solution": report,
+            "reasoning": reasoning,
+            "topology": topology,
+            "epoch": epoch,
+        }
+        return QNNResult(
+            mode="brainstorm",
+            proposed_solution=report,
+            reasoning=reasoning,
+            topology=topology,
+            seed_pool=all_seed_words,
+            column_guiding_words=column_guiding_words,
+            agent_personas=agent_personas,
+            attention_edges=attention_edges,
+            epoch_maps=epoch_maps,
+            final_solution=final,
+            params=p,
+        ).to_dict()
+
     for epoch in range(epochs):
         await _log(log, f"--- [QNN STEP 4] Epoch {epoch}/{epochs - 1} forward ---")
         agent_outputs: Dict[str, Any] = {}
 
         for i in range(layers):
-            for j in range(width):
-                node_id = f"agent_{i}_{j}"
-                persona = agent_personas[node_id]
-                agent_prompt = (
-                    f"YOU ARE {str(persona.get('name', 'Expert')).upper()}, "
-                    f"A {str(persona.get('specialty', 'Specialist')).upper()}.\n\n"
-                    f"{persona.get('system_prompt', '')}"
-                )
+            prev_layer_outputs: List[Any] = []
+            if i > 0:
+                for k in range(width):
+                    prev_id = f"agent_{i - 1}_{k}"
+                    if prev_id in agent_outputs:
+                        up = agent_outputs[prev_id]
+                        if isinstance(up, dict):
+                            prev_layer_outputs.append({"agent_id": prev_id, **up})
+                        else:
+                            prev_layer_outputs.append({"agent_id": prev_id, "output": up})
 
-                # Upstream = previous layer (graph neighbors)
-                prev_layer_outputs: List[Any] = []
-                if i > 0:
-                    for k in range(width):
-                        prev_id = f"agent_{i - 1}_{k}"
-                        if prev_id in agent_outputs:
-                            up = agent_outputs[prev_id]
-                            if isinstance(up, dict):
-                                prev_layer_outputs.append({"agent_id": prev_id, **up})
-                            else:
-                                prev_layer_outputs.append({"agent_id": prev_id, "output": up})
-
-                # Qualitative self-attention over non-local past neurons
-                attention_block = ""
-                if enable_attn and top_k > 0:
-                    state_snap = {
-                        "epoch": epoch,
-                        "all_layers_prompts": all_layers_prompts,
-                        "agent_personas": agent_personas,
-                        "agent_outputs": agent_outputs,
-                        "memory": memory,
-                    }
-                    try:
-                        edges, attention_block = compute_self_attention(
-                            state_snap, node_id, top_k=top_k
-                        )
-                        if edges:
-                            attention_edges[node_id] = [e.to_dict() for e in edges]
-                            await _log(
-                                log,
-                                f"LOG: [QNN ATTEND] {node_id} → "
-                                + ", ".join(f"{e.to_id}({e.strength})" for e in edges),
-                            )
-                    except Exception as ae:
-                        await _log(log, f"WARNING: [QNN ATTEND] {node_id}: {ae}")
-
-                if i == 0:
-                    input_data = f"""## QNN Brief
-{brief}
-
-## Original Request (ground truth — do not replace)
-{user_prompt}
-
-## Thinking Challenge (epoch {epoch})
-{current_problem}
-
-## Layer 0 Role
-Divergent exploration. Span strategies and mechanisms. Do NOT write production patches.
-
-{attention_block}
-"""
-                else:
-                    input_data = f"""## QNN Brief
-{brief}
-
-## Original Request (ground truth — do not replace)
-{user_prompt}
-
-## Thinking Challenge (epoch {epoch})
-{current_problem}
-
-## Layer {i} Role
-Convergent / critical. Critique or combine upstream. Cite agent_id. No production patches.
-
-## Upstream Layer Outputs (graph neighbors)
-{json.dumps(prev_layer_outputs, indent=2)}
-
-{attention_block}
-"""
-
-                mem_str = "\n".join(f"- {json.dumps(m)}" for m in memory.get(node_id, [])[-5:])
-                full_prompt = f"""
-#System Prompt (Your Persona & Task):
----
-{agent_prompt}
----
-#Your Memory (Past Actions):
----
-{mem_str or "No past actions."}
----
-#Input Data to Process:
----
-{input_data}
----
-# Your JSON response (required keys):
-{{
-  "original_problem": "<brief or challenge you addressed>",
-  "proposed_solution": "<strategic angle / mechanism — NOT a production patch>",
-  "reasoning": "<why this might break the impasse>",
-  "falsifiers": "<evidence that would kill this angle>",
-  "risks": "<ways it could fail>",
-  "skills_used": []
-}}
-"""
-                raw_out = await agent_chain.ainvoke({"input": full_prompt})
-                parsed = clean_and_parse_json(raw_out)
-                if not isinstance(parsed, dict):
-                    parsed = {
-                        "original_problem": current_problem,
-                        "proposed_solution": str(raw_out)[:2000],
-                        "reasoning": "unparsed agent output",
-                        "falsifiers": "",
-                        "risks": "",
-                        "skills_used": [],
-                    }
+            snapshot = dict(agent_outputs)
+            layer_results = await asyncio.gather(
+                *[
+                    _run_agent_cell(
+                        agent_chain,
+                        node_id=f"agent_{i}_{j}",
+                        layer_index=i,
+                        persona=agent_personas[f"agent_{i}_{j}"],
+                        brief=brief,
+                        user_prompt=user_prompt,
+                        current_problem=current_problem,
+                        epoch=epoch,
+                        prev_layer_outputs=prev_layer_outputs,
+                        memory=memory,
+                        agent_outputs_snapshot=snapshot,
+                        all_layers_prompts=all_layers_prompts,
+                        agent_personas=agent_personas,
+                        enable_attn=enable_attn,
+                        top_k=top_k,
+                        log=log,
+                    )
+                    for j in range(width)
+                ]
+            )
+            for node_id, parsed, edge_dicts in layer_results:
                 agent_outputs[node_id] = parsed
                 memory.setdefault(node_id, []).append(parsed)
+                if edge_dicts:
+                    attention_edges[node_id] = edge_dicts
                 await _log(
                     log,
                     f"SUCCESS: {node_id} epoch={epoch} "
                     f"sol={str(parsed.get('proposed_solution', ''))[:80]}…",
                 )
+
+        _persist_session(
+            session_store,
+            session_id,
+            {
+                "agent_outputs": dict(agent_outputs),
+                "memory": {k: list(v) for k, v in memory.items()},
+                "attention_edges": dict(attention_edges),
+                "agent_personas": agent_personas,
+                "all_layers_prompts": all_layers_prompts,
+                "epoch": epoch,
+                "current_problem": current_problem,
+            },
+        )
 
         # Epoch map / synthesis
         reflections = []
@@ -457,10 +559,11 @@ Convergent / critical. Critique or combine upstream. Cite agent_id. No productio
             epoch_maps.append(epoch_map)
             previous_solution = epoch_map
 
-            # Mirror Descent
+            # Mirror Descent — evolve every persona in parallel
             await _log(log, "LOG: [QNN STEP 4C] Mirror Descent (persona evolution)...")
             md = get_brainstorming_mirror_descent_chain(llm, lr)
-            for nid, persona in list(agent_personas.items()):
+
+            async def _evolve(nid: str, persona: dict):
                 try:
                     out = agent_outputs.get(nid, {})
                     new_prompt = await md.ainvoke(
@@ -470,11 +573,22 @@ Convergent / critical. Critique or combine upstream. Cite agent_id. No productio
                         }
                     )
                     if isinstance(new_prompt, str) and len(new_prompt.strip()) > 40:
-                        persona["system_prompt"] = new_prompt.strip()
-                        li, wi = map(int, nid.split("_")[1:])
-                        all_layers_prompts[li][wi] = persona["system_prompt"]
+                        return nid, new_prompt.strip(), None
+                    return nid, None, None
                 except Exception as me:
-                    await _log(log, f"WARNING: Mirror Descent failed for {nid}: {me}")
+                    return nid, None, me
+
+            evolved = await asyncio.gather(
+                *[_evolve(nid, persona) for nid, persona in list(agent_personas.items())]
+            )
+            for nid, new_prompt, err in evolved:
+                if err is not None:
+                    await _log(log, f"WARNING: Mirror Descent failed for {nid}: {err}")
+                    continue
+                if new_prompt:
+                    agent_personas[nid]["system_prompt"] = new_prompt
+                    li, wi = map(int, nid.split("_")[1:])
+                    all_layers_prompts[li][wi] = new_prompt
 
             # Reframe
             await _log(log, "LOG: [QNN STEP 4D] Reframe thinking challenge...")
@@ -493,8 +607,8 @@ Convergent / critical. Critique or combine upstream. Cite agent_id. No productio
                 elif isinstance(reframed, str) and reframed.strip():
                     current_problem = reframed.strip()
                 await _log(log, f"LOG: [QNN STEP 4D] New challenge: {current_problem[:160]}…")
-            except Exception as re:
-                await _log(log, f"WARNING: reframe failed: {re}")
+            except Exception as re_err:
+                await _log(log, f"WARNING: reframe failed: {re_err}")
         else:
             await _log(log, "LOG: [QNN STEP 5] Final Solution-Space Report...")
             draft = await get_brainstorming_synthesis_chain(synth).ainvoke(
@@ -512,32 +626,32 @@ Convergent / critical. Critique or combine upstream. Cite agent_id. No productio
                 }
             )
             report = polished if isinstance(polished, str) and polished.strip() else draft
-            final = {
-                "mode": "brainstorm",
-                "proposed_solution": report,
-                "reasoning": "QNN Solution-Space Report complete.",
-                "topology": topology,
-                "epoch": epoch,
-            }
-            result = QNNResult(
-                mode="brainstorm",
-                proposed_solution=report,
-                reasoning=final["reasoning"],
-                topology=topology,
-                seed_pool=all_seed_words,
-                column_guiding_words=column_guiding_words,
-                agent_personas=agent_personas,
-                attention_edges=attention_edges,
-                epoch_maps=epoch_maps,
-                final_solution=final,
-                params=p,
+            result = _build_result(report, epoch, "QNN Solution-Space Report complete.")
+            _persist_session(
+                session_store,
+                session_id,
+                {
+                    "final_solution": result["final_solution"],
+                    "agent_personas": agent_personas,
+                    "attention_edges": attention_edges,
+                    "all_layers_prompts": all_layers_prompts,
+                    "column_guiding_words": column_guiding_words,
+                    "epoch_maps": epoch_maps,
+                },
             )
+            await _log(log, f"FINAL_ANSWER: {json.dumps(result['final_solution'])}")
             await _log(log, "SUCCESS: [QNN] Solution-Space Report complete.")
-            return result.to_dict()
+            return result
 
     # Fallback if epochs==0 somehow
-    return QNNResult(
+    fallback_result = QNNResult(
         proposed_solution="QNN completed without a final report.",
         topology=topology,
         params=p,
     ).to_dict()
+    _persist_session(
+        session_store,
+        session_id,
+        {"final_solution": fallback_result.get("final_solution") or fallback_result},
+    )
+    return fallback_result

--- a/deepthink/utils.py
+++ b/deepthink/utils.py
@@ -2,11 +2,17 @@
 Core utilities and shared functions for DeepThink.
 """
 
-import re
+from __future__ import annotations
+
+import ast
 import json
-import io
-import asyncio
-from contextlib import redirect_stdout, redirect_stderr
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Optional
 
 
 def clean_and_parse_json(llm_output_string):
@@ -18,6 +24,13 @@ def clean_and_parse_json(llm_output_string):
     - C-style comments (// and /* */)
     - Unescaped newlines/tabs inside strings (common LLM error)
     """
+    if llm_output_string is None:
+        return None
+    if isinstance(llm_output_string, dict):
+        return llm_output_string
+    if not isinstance(llm_output_string, str):
+        llm_output_string = str(llm_output_string)
+
     match = re.search(r"```json\s*([\s\S]*?)\s*```", llm_output_string)
     if match:
         json_string = match.group(1)
@@ -27,7 +40,6 @@ def clean_and_parse_json(llm_output_string):
             end_index = llm_output_string.rindex("}") + 1
             json_string = llm_output_string[start_index:end_index]
         except ValueError:
-            # print("Error: No JSON object found in the string.")
             return None
 
     # Step 1: Remove Comments (C-style) while preserving strings
@@ -99,47 +111,313 @@ def clean_and_parse_json(llm_output_string):
         return json.loads(repaired_string)
     except json.JSONDecodeError as e:
         print(f"Error decoding JSON even after repair: {e}")
-        # print(f"Problematic string start: {json_string[:200]}")
         return None
 
 
-def execute_code_in_sandbox(code: str) -> tuple:
+def parse_llm_json(raw: Any, default: Optional[dict] = None) -> dict:
+    """Parse an LLM payload into a dict (fenced / messy JSON included)."""
+    if isinstance(raw, dict):
+        return raw
+    parsed = clean_and_parse_json(raw)
+    if isinstance(parsed, dict):
+        return parsed
+    return {} if default is None else default
+
+
+_TIKTOKEN_ENC = None
+_TIKTOKEN_FAILED = False
+
+
+def estimate_tokens(text: Any) -> int:
     """
-    Executes a string of Python code and captures its stdout/stderr.
-    Returns a tuple of (success: bool, output: str).
+    Count tokens for budget accounting.
+
+    Prefers tiktoken ``cl100k_base`` (OpenRouter / OpenAI-compatible). Falls
+    back to a ~4-chars-per-token heuristic when tiktoken is unavailable.
+    """
+    if text is None:
+        return 0
+    if not isinstance(text, str):
+        text = str(text)
+    if not text:
+        return 0
+
+    global _TIKTOKEN_ENC, _TIKTOKEN_FAILED
+    if not _TIKTOKEN_FAILED:
+        try:
+            if _TIKTOKEN_ENC is None:
+                import tiktoken
+
+                _TIKTOKEN_ENC = tiktoken.get_encoding("cl100k_base")
+            return len(_TIKTOKEN_ENC.encode(text, disallowed_special=()))
+        except Exception:
+            _TIKTOKEN_FAILED = True
+    return max(1, (len(text) + 3) // 4)
+
+
+# ---------------------------------------------------------------------------
+# Isolated code sandbox
+# ---------------------------------------------------------------------------
+
+class SandboxError(Exception):
+    """Raised when user code is rejected before execution."""
+
+
+_FORBIDDEN_NAMES = frozenset(
+    {
+        "__import__",
+        "open",
+        "exec",
+        "eval",
+        "compile",
+        "input",
+        "breakpoint",
+        "globals",
+        "locals",
+        "vars",
+        "getattr",
+        "setattr",
+        "delattr",
+        "hasattr",
+        "type",
+        "object",
+        "super",
+        "classmethod",
+        "staticmethod",
+        "property",
+        "memoryview",
+        "help",
+        "exit",
+        "quit",
+        "copyright",
+        "credits",
+        "license",
+        "__builtins__",
+        "__loader__",
+        "__spec__",
+        "os",
+        "sys",
+        "subprocess",
+        "socket",
+        "shutil",
+        "pathlib",
+        "importlib",
+        "ctypes",
+        "multiprocessing",
+        "builtins",
+    }
+)
+
+_SAFE_BUILTINS = (
+    "print",
+    "range",
+    "len",
+    "str",
+    "int",
+    "float",
+    "list",
+    "dict",
+    "set",
+    "tuple",
+    "bool",
+    "abs",
+    "min",
+    "max",
+    "sum",
+    "enumerate",
+    "zip",
+    "map",
+    "filter",
+    "sorted",
+    "reversed",
+    "round",
+    "isinstance",
+    "any",
+    "all",
+    "ord",
+    "chr",
+    "bin",
+    "hex",
+    "oct",
+    "pow",
+    "divmod",
+    "repr",
+    "format",
+    "slice",
+    "iter",
+    "next",
+    "True",
+    "False",
+    "None",
+)
+
+
+class _SandboxVisitor(ast.NodeVisitor):
+    def visit_Import(self, node):
+        raise SandboxError("imports are not allowed")
+
+    def visit_ImportFrom(self, node):
+        raise SandboxError("imports are not allowed")
+
+    def visit_Attribute(self, node):
+        if isinstance(node.attr, str) and node.attr.startswith("_"):
+            raise SandboxError(f"attribute {node.attr!r} is not allowed")
+        self.generic_visit(node)
+
+    def visit_Name(self, node):
+        if node.id in _FORBIDDEN_NAMES or node.id.startswith("__"):
+            raise SandboxError(f"name {node.id!r} is not allowed")
+        self.generic_visit(node)
+
+    def visit_Global(self, node):
+        raise SandboxError("global is not allowed")
+
+    def visit_Nonlocal(self, node):
+        raise SandboxError("nonlocal is not allowed")
+
+
+def _assert_sandbox_ast_safe(code: str) -> ast.AST:
+    try:
+        tree = ast.parse(code, filename="<sandbox>", mode="exec")
+    except SyntaxError as e:
+        raise SandboxError(f"SyntaxError: {e}") from e
+    _SandboxVisitor().visit(tree)
+    return tree
+
+
+def _sandbox_env() -> dict:
+    env = {
+        "PYTHONIOENCODING": "utf-8",
+        "PYTHONSAFEPATH": "1",
+        "PYTHONNOUSERSITE": "1",
+        "PYTHONDONTWRITEBYTECODE": "1",
+    }
+    if os.name == "nt":
+        for key in ("SYSTEMROOT", "SYSTEMDRIVE", "WINDIR", "TEMP", "TMP", "COMSPEC"):
+            if key in os.environ:
+                env[key] = os.environ[key]
+    else:
+        env["PATH"] = "/usr/bin:/bin"
+        env["HOME"] = tempfile.gettempdir()
+        env["TMPDIR"] = tempfile.gettempdir()
+    return env
+
+
+_SANDBOX_RUNNER = r'''
+import ast
+import io
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+
+FORBIDDEN = frozenset({
+    "__import__", "open", "exec", "eval", "compile", "input", "breakpoint",
+    "globals", "locals", "vars", "getattr", "setattr", "delattr", "hasattr",
+    "type", "object", "super", "classmethod", "staticmethod", "property",
+    "memoryview", "help", "exit", "quit", "copyright", "credits", "license",
+    "__builtins__", "__loader__", "__spec__", "os", "sys", "subprocess",
+    "socket", "shutil", "pathlib", "importlib", "ctypes", "multiprocessing",
+    "builtins",
+})
+
+class V(ast.NodeVisitor):
+    def visit_Import(self, node):
+        raise RuntimeError("imports are not allowed")
+    def visit_ImportFrom(self, node):
+        raise RuntimeError("imports are not allowed")
+    def visit_Attribute(self, node):
+        if isinstance(node.attr, str) and node.attr.startswith("_"):
+            raise RuntimeError("attribute %r is not allowed" % (node.attr,))
+        self.generic_visit(node)
+    def visit_Name(self, node):
+        if node.id in FORBIDDEN or node.id.startswith("__"):
+            raise RuntimeError("name %r is not allowed" % (node.id,))
+        self.generic_visit(node)
+    def visit_Global(self, node):
+        raise RuntimeError("global is not allowed")
+    def visit_Nonlocal(self, node):
+        raise RuntimeError("nonlocal is not allowed")
+
+SAFE = {
+    "print": print, "range": range, "len": len, "str": str, "int": int,
+    "float": float, "list": list, "dict": dict, "set": set, "tuple": tuple,
+    "bool": bool, "abs": abs, "min": min, "max": max, "sum": sum,
+    "enumerate": enumerate, "zip": zip, "map": map, "filter": filter,
+    "sorted": sorted, "reversed": reversed, "round": round,
+    "isinstance": isinstance, "any": any, "all": all, "ord": ord, "chr": chr,
+    "bin": bin, "hex": hex, "oct": oct, "pow": pow, "divmod": divmod,
+    "repr": repr, "format": format, "slice": slice, "iter": iter, "next": next,
+    "True": True, "False": False, "None": None,
+}
+
+src_path = sys.argv[1]
+with open(src_path, "r", encoding="utf-8") as fh:
+    code = fh.read()
+try:
+    tree = ast.parse(code, filename="<sandbox>", mode="exec")
+    V().visit(tree)
+except Exception as e:
+    sys.stderr.write("%s: %s\n" % (type(e).__name__, e))
+    sys.exit(2)
+
+buf = io.StringIO()
+try:
+    with redirect_stdout(buf), redirect_stderr(buf):
+        exec(compile(tree, "<sandbox>", "exec"), {"__builtins__": SAFE}, {})
+except Exception as e:
+    sys.stdout.write(buf.getvalue())
+    sys.stderr.write("ERROR: %s: %s\n" % (type(e).__name__, e))
+    sys.exit(1)
+sys.stdout.write(buf.getvalue())
+'''
+
+
+def _extract_sandbox_source(code: str) -> str:
+    code_match = re.search(r"```(?:python\n)?([\s\S]*?)```", code)
+    if code_match:
+        return code_match.group(1).strip()
+    return code.strip()
+
+
+def execute_code_in_sandbox(code: str, timeout: float = 5.0) -> tuple:
+    """
+    Execute Python in an isolated subprocess after AST rejection of imports
+    and dunder / filesystem escapes.
+
+    Returns ``(success: bool, output: str)``.
     """
     if not code:
         return True, "No code to execute."
 
-    # Extract code from markdown block if present
-    code_match = re.search(r"```(?:python\n)?([\s\S]*?)```", code)
-    if code_match:
-        code = code_match.group(1).strip()
+    source = _extract_sandbox_source(code)
+    if not source:
+        return True, "No code to execute."
 
-    output_buffer = io.StringIO()
     try:
-        with redirect_stdout(output_buffer), redirect_stderr(output_buffer):
-            # Using a restricted globals dict for a little more safety
-            exec(
-                code,
-                {
-                    "__builtins__": {
-                        "print": print,
-                        "range": range,
-                        "len": len,
-                        "str": str,
-                        "int": int,
-                        "float": float,
-                        "list": list,
-                        "dict": dict,
-                        "set": set,
-                        "tuple": tuple,
-                        "True": True,
-                        "False": False,
-                        "None": None,
-                    }
-                },
+        _assert_sandbox_ast_safe(source)
+    except SandboxError as e:
+        return False, f"ERROR: {type(e).__name__}: {e}"
+
+    try:
+        with tempfile.TemporaryDirectory(prefix="odt-sandbox-") as tmp:
+            tmp_path = Path(tmp)
+            user_path = tmp_path / "user.py"
+            runner_path = tmp_path / "_runner.py"
+            user_path.write_text(source, encoding="utf-8")
+            runner_path.write_text(_SANDBOX_RUNNER, encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, "-I", str(runner_path), str(user_path)],
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=str(tmp_path),
+                env=_sandbox_env(),
             )
-        return True, output_buffer.getvalue()
+    except subprocess.TimeoutExpired:
+        return False, f"ERROR: TimeoutError: sandbox exceeded {timeout}s"
     except Exception as e:
-        return False, f"{output_buffer.getvalue()}\n\nERROR: {type(e).__name__}: {e}"
+        return False, f"ERROR: {type(e).__name__}: {e}"
+
+    output = (proc.stdout or "") + (proc.stderr or "")
+    if proc.returncode != 0:
+        return False, output or f"ERROR: sandbox exited {proc.returncode}"
+    return True, output

--- a/tests/phase2_utils.py
+++ b/tests/phase2_utils.py
@@ -3,7 +3,12 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 import sys
 sys.path.insert(0, str(ROOT))
-from deepthink.utils import clean_and_parse_json, execute_code_in_sandbox
+from deepthink.utils import (
+    clean_and_parse_json,
+    estimate_tokens,
+    execute_code_in_sandbox,
+    parse_llm_json,
+)
 results = []
 def chk(name, fn):
     try:
@@ -71,6 +76,27 @@ def t15():
     success, _ = execute_code_in_sandbox("open('test.txt')")
     assert not success, "Sandbox must NOT allow open()"
 chk("sandbox blocks open() (security)", t15)
+
+def t16():
+    success, _ = execute_code_in_sandbox("print(('').__class__.__mro__)")
+    assert not success, "Sandbox must NOT allow dunder attribute walks"
+chk("sandbox blocks dunder attribute escape", t16)
+
+def t18():
+    n = estimate_tokens("hello world")
+    assert isinstance(n, int) and n >= 1
+    assert estimate_tokens("") == 0
+    assert estimate_tokens(None) == 0
+    long_n = estimate_tokens("word " * 200)
+    assert long_n > n
+chk("estimate_tokens returns positive counts", t18)
+
+def t19():
+    assert parse_llm_json('```json\n{"a": 1}\n```') == {"a": 1}
+    assert parse_llm_json({"already": True}) == {"already": True}
+    assert parse_llm_json("not json") == {}
+    assert parse_llm_json("not json", default={"ok": False}) == {"ok": False}
+chk("parse_llm_json handles messy LLM payloads", t19)
 
 for name, status, err in results:
     line = f"  [{status}] {name}"

--- a/tests/phase6_distillation.py
+++ b/tests/phase6_distillation.py
@@ -96,10 +96,13 @@ chk("DistillationGraph initializes 12 unique agents across 7 layers", t4)
 # 5) _estimate_tokens
 def t5():
     g = DistillationGraph(DistillationMockLLM(), ["t"], "a")
-    assert g._estimate_tokens("a" * 100) == 25
+    n = g._estimate_tokens("a" * 100)
+    assert isinstance(n, int) and n >= 1
+    assert g._estimate_tokens("") == 0
+    assert g._estimate_tokens("word " * 400) > n
 
 
-chk("_estimate_tokens (1 token ~ 4 chars)", t5)
+chk("_estimate_tokens counts text (tiktoken or heuristic)", t5)
 
 
 # 6) total_tokens

--- a/tests/phase_package_api.py
+++ b/tests/phase_package_api.py
@@ -170,6 +170,20 @@ def t4():
 chk("run_qnn + run_qdad library pipelines (mock LLM)", t4)
 
 
+def t4b():
+    from deepthink.qnn.pipeline import _clamp_topology
+
+    # Auto mode: soft-cap width so L*W stays ≤ 60
+    layers, width, epochs = _clamp_topology(10, 20, 3, manual=False)
+    assert layers * width <= 60
+    # Manual / massive: 10×10 must survive (README massive mode)
+    layers, width, epochs = _clamp_topology(10, 10, 4, manual=True)
+    assert (layers, width, epochs) == (10, 10, 4)
+
+
+chk("QNN topology clamp: auto caps, manual does not shrink 10×10", t4b)
+
+
 def t5():
     from deepthink.distillation import DistillationGraph
 


### PR DESCRIPTION
## Summary
Engineering fixes from the 0.2.1 review. README / public docs are unchanged.

- Brainstorm UI now runs `deepthink.qnn.run_qnn_pipeline` (same engine as the library API and `/qnn` skill)
- QNN persona span, per-layer forward pass, and Mirror Descent run in parallel
- Manual / massive topologies are no longer silently capped at 60 agents
- `execute_code_in_sandbox` is AST-gated and isolated in a subprocess; duplicate copy removed from `app.py`
- Distillation token accounting uses tiktoken when available
- Distillation LLM JSON goes through `parse_llm_json` instead of raw `json.loads`
- Distillation Mirror Descent evaluations run concurrently

## Tests
`python tests/run_all.py` — 244/244 OK

## Release
Tag `0.2.2` is already pushed and should be published after this lands on main.